### PR TITLE
POC of using Context class instead Activity class to init ZeroPush

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
+        android:name=".DemoApp"
         android:theme="@style/AppTheme" >
         <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
         <activity

--- a/app/src/main/java/com/zeropush/zeropush_gcm_demo/DemoApp.java
+++ b/app/src/main/java/com/zeropush/zeropush_gcm_demo/DemoApp.java
@@ -1,0 +1,39 @@
+package com.zeropush.zeropush_gcm_demo;
+
+import android.app.Application;
+import android.util.Log;
+
+import com.zeropush.sdk.ZeroPush;
+import com.zeropush.sdk.ZeroPushResponseHandler;
+
+import org.json.JSONObject;
+
+public class DemoApp extends Application {
+
+    private static ZeroPush zeroPush;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        zeroPush = new ZeroPush("zeropush-app-token", "gcm-project-number", this);
+        zeroPush.verifyCredentials(new ZeroPushResponseHandler(){
+            @Override
+            public void handle(JSONObject response, int statusCode, Error error) {
+                if(error != null) {
+                    Log.e("DemoApp", error.getMessage());
+                    return;
+                }
+                Log.d("DemoApp", response.toString());
+            }
+        });
+
+        zeroPush.registerForRemoteNotifications();
+    }
+
+    public static ZeroPush getZeroPush() {
+        return zeroPush;
+    }
+
+
+}

--- a/app/src/main/java/com/zeropush/zeropush_gcm_demo/Notifications.java
+++ b/app/src/main/java/com/zeropush/zeropush_gcm_demo/Notifications.java
@@ -1,51 +1,26 @@
 package com.zeropush.zeropush_gcm_demo;
 
 import android.annotation.TargetApi;
-import android.os.StrictMode;
-import android.os.Build;
-
 import android.app.Activity;
+import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
+import android.os.StrictMode;
 import android.view.Menu;
 import android.view.MenuItem;
 
-import com.zeropush.sdk.ZeroPush;
-import com.zeropush.sdk.ZeroPushResponseHandler;
-
-import org.apache.http.Header;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 
 public class Notifications extends Activity {
-
-    private ZeroPush zeroPush;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_notifications);
-        zeroPush = new ZeroPush("zeropush-app-token", "gcm-project-number", this);
-        zeroPush.verifyCredentials(new ZeroPushResponseHandler(){
-            @Override
-            public void handle(JSONObject response, int statusCode, Error error) {
-                if(error != null) {
-                    Log.e("DemoApp", error.getMessage());
-                    return;
-                }
-                Log.d("DemoApp", response.toString());
-            }
-        });
-
-        zeroPush.registerForRemoteNotifications();
         activateStrictMode();
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        //zeroPush.registerForRemoteNotifications();
     }
 
     @Override

--- a/zeropush-sdk/src/main/java/com/zeropush/sdk/ZeroPush.java
+++ b/zeropush-sdk/src/main/java/com/zeropush/sdk/ZeroPush.java
@@ -5,7 +5,6 @@ package com.zeropush.sdk;
  */
 
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
@@ -13,17 +12,17 @@ import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.util.Log;
 
-import org.apache.http.Header;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.gcm.GoogleCloudMessaging;
+import com.loopj.android.http.AsyncHttpClient;
+import com.loopj.android.http.RequestParams;
+import com.loopj.android.http.ResponseHandlerInterface;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Iterator;
 import java.util.List;
-import org.json.*;
-import com.loopj.android.http.*;
-
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.android.gms.gcm.GoogleCloudMessaging;
 
 public class ZeroPush {
 
@@ -46,12 +45,12 @@ public class ZeroPush {
     private String apiKey;
     private String senderId;
     private String deviceToken;
-    private Activity delegate;
+    private Context delegate;
 
-    public ZeroPush(String apiKey, String senderId, Activity delegate){
+    public ZeroPush(String apiKey, String senderId, Context context){
         this.apiKey = apiKey;
         this.senderId = senderId;
-        this.delegate = delegate;
+        this.delegate = context;
         httpClient.setUserAgent(UserAgent);
         sharedInstance = this;
     }
@@ -262,10 +261,9 @@ public class ZeroPush {
         int resultCode = GooglePlayServicesUtil.isGooglePlayServicesAvailable(delegate);
         if (resultCode != ConnectionResult.SUCCESS) {
             if (GooglePlayServicesUtil.isUserRecoverableError(resultCode)) {
-                GooglePlayServicesUtil.getErrorDialog(resultCode, delegate, PLAY_SERVICES_RESOLUTION_REQUEST).show();
+                Log.e(TAG, "There was a problem to init Google Play Services");
             } else {
                 Log.i(TAG, "This device is not supported.");
-                delegate.finish();
             }
             return false;
         }


### PR DESCRIPTION
Hi,

Have a look. I replaced type of delegate to init ZeroPush. I think that using context is a little bit better approach. It also suggest that you have to init it once. If you want to store reference to it, having it in application class is a good place for that.